### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,19 +2,19 @@
 
 A simple adition to `UITabBarController` which allows changing tabs with left and right swipe gestures on the tab bar.
 
-#Why?
+# Why?
 
 If you've used an iOS app with 5+ tabs on a iPhone 6+, you know that depending on your grip, it may be hard to reach the first/last tab icons.
 
-#Implementation
+# Implementation
 
 I've provided two versions, one in Objective-C and the other in Swift. They use a Category and an Extension respectively.
 
 Both add two `UISwipeGestureRecognizers` to the `UITabBar` and provides methods for handling swipes in each direction, with or without cycling behavior (going from the last to the first tab when swiping right and from the first to the last tab when swiping left)
 
-#Usage
+# Usage
 
-##Objective-C
+## Objective-C
 
 Include `UITabBarController+Swipe.h` in your project and import it in the `AppDelegate` implementation. Setup the `UITabBarController` with:
 
@@ -28,7 +28,7 @@ To activate the cycling behavior, use:
 
     [tabBarController setupSwipeGestureRecognizersAllowCyclingThroughTabs:YES];
 
-##Swift
+## Swift
 
 Include `TabBarControllerSwipeExtension.swift` in your project. Inside `application:DidFinishLauncingWithOptions:` setup the gesture recognizer as follows:
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
