### PR TITLE
Update .Left and .Right (deprecated) to .left and .right

### DIFF
--- a/SwipeTabBar-Swift/SwipeTabBar-Swift/TabBarControllerSwipeExtension.swift
+++ b/SwipeTabBar-Swift/SwipeTabBar-Swift/TabBarControllerSwipeExtension.swift
@@ -11,11 +11,11 @@ import UIKit
 extension UITabBarController {
     func setupSwipeGestureRecognizers(allowCyclingThoughTabs cycleThroughTabs: Bool = false) {
         let swipeLeftGestureRecognizer = UISwipeGestureRecognizer(target: self, action: cycleThroughTabs ? #selector(handleSwipeLeftAllowingCyclingThroughTabs) : #selector(handleSwipeLeft))
-        swipeLeftGestureRecognizer.direction = .Left
+        swipeLeftGestureRecognizer.direction = .left
         self.tabBar.addGestureRecognizer(swipeLeftGestureRecognizer)
         
         let swipeRightGestureRecognizer = UISwipeGestureRecognizer(target: self, action: cycleThroughTabs ? #selector(handleSwipeRightAllowingCyclingThroughTabs) : #selector(handleSwipeRight))
-        swipeRightGestureRecognizer.direction = .Right
+        swipeRightGestureRecognizer.direction = .right
         self.tabBar.addGestureRecognizer(swipeRightGestureRecognizer)
     }
     


### PR DESCRIPTION
Just updated constants name avoiding error with Swift 3